### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To play: arrow keys to rotate, and move. `space` to fire. `P` to pause. `Q` to q
 
 You will need the Haskell toot stack to compile this program from source. Instructions for installation can be found [here.](https://docs.haskellstack.org/en/stable/README/)
 
-After stack isa installed, you will also need to install `sdl2`, `sdl2_ttf` and `sdl2_image`.  On a mac, this can be done with Homebrew:
+After stack is installed, you will also need to install `sdl2`, `sdl2_ttf` and `sdl2_image`.  On a mac, this can be done with Homebrew:
 
 ```bash
 brew install sdl2 sdl2_ttf sdl2_image


### PR DESCRIPTION
1. Typo. "After stack isa installed" changes to "After stack is installed".
Fixes #1 